### PR TITLE
Stop bold menu items from moving the menu

### DIFF
--- a/src/styles/partials/_header.scss
+++ b/src/styles/partials/_header.scss
@@ -13,6 +13,16 @@
 			color: #091440;
 			border-bottom: 5px solid #2ed8a3;
 		}
+
+		&:after {
+			display: block;
+			content: attr(title);
+			font-weight: bold;
+			height: 1px;
+			color: transparent;
+			overflow: hidden;
+			visibility: hidden;
+		}
 	}
 
 	.logo {

--- a/src/styles/partials/_helpers.scss
+++ b/src/styles/partials/_helpers.scss
@@ -18,6 +18,7 @@ img + span {
 }
 
 html {
+	overflow-y: overlay;
 	position: relative;
 	min-height: 100%;
 }


### PR DESCRIPTION
The nav menu is in a slighly different location on each page. This is because the current menu item is highlighted in bold, which makes it's container slightly wider.

This PR sets all of the elements to their bold width, regardless of whether the text is actually bold or not. This means that all containers are constantly the same width, and the nav menu is always in the same location.

Solution taken from https://stackoverflow.com/a/32570813/1428338