### PR TITLE
Stats page improvements

### DIFF
--- a/src/stats.html
+++ b/src/stats.html
@@ -81,7 +81,7 @@
 			    			<h1><span>Stats and Status</span></h1>
 			    		</div>
 			    		<div class="col-12 mb-4">
-			    			<div class="row row--stats">
+			    			<div class="row">
 			    				<div class="col text-center bg-white py-2">
 			    					<p class="font-weight-bold text--size-13 mb-0">Live</p>
 			    					<p class="mb-0 text--size-13">671</p>

--- a/src/stats.html
+++ b/src/stats.html
@@ -167,8 +167,8 @@
 				    				</div>
 				    			</div>
 				    		</div>
-				    		<div class="col-md-6 col-12 px-md-3 px-5">
-				    			<div class="row ml-lg-0">
+				    		<div class="col-md-6 col-12 px-md-3">
+				    			<div class="row">
 				    				<div class="col-12 px-5 mb-3">
 					    				<h1>Pool Tickets</h1>
 					    			</div>

--- a/src/styles/partials/_layout.scss
+++ b/src/styles/partials/_layout.scss
@@ -241,10 +241,6 @@
 }
 
 .row {
-	&--stats {
-	    margin-right: -50px;
-	}
-
 	&--voting {
 		margin-top: 20px;
 	}


### PR DESCRIPTION
This fixes two issues for mobile:
- the third chart on the stats page was not the same size as the other two
- a negative margin was causing unnecessary horizontal scrolling on the stats page