### PR TITLE
Remove link from navbar greeting

### DIFF
--- a/src/connect-to-wallet.html
+++ b/src/connect-to-wallet.html
@@ -38,7 +38,7 @@
 				        <a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="settings.html">Settings</a>
 			        </div>
 			        <div class="col-3 px-0 position-relative d-flex justify-content-end">
-			        	<a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="#">Hello, <span class="e-mail">maria@gr.co</span></a>
+			        	<p class="mr-5 pt-2 pb-3 d-none d-xl-inline-block">Hello, <span class="e-mail">maria@gr.co</span></p>
 			        	<a class="pt-2 pb-3 d-none d-xl-inline-block" href="#">Logout</a>
 			        	<div id="sidebarCollapse" class="wrapper py-1 d-inline-block d-xl-none">
 							<div class="menu-trigger first">
@@ -62,7 +62,7 @@
 				</div>
             </div>
             <ul class="mb-5">
-            	<li><a href="#">Hello, <span class="e-mail">maria@gr.co</span></a></li>
+            	<li><p>Hello, <span class="e-mail">maria@gr.co</span></p></li>
             	<li><a href="index.html">Home</a></li>
             	<li><a href="stats.html">Stats</a></li>
             	<li><a class="active" href="connect-to-wallet.html">Connect to Wallet</a></li>

--- a/src/connected-to-wallet.html
+++ b/src/connected-to-wallet.html
@@ -38,7 +38,7 @@
 				        <a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="settings.html">Settings</a>
 			        </div>
 			        <div class="col-3 px-0 position-relative d-flex justify-content-end">
-			        	<a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="#">Hello, <span class="e-mail">maria@gr.co</span></a>
+			        	<p class="mr-5 pt-2 pb-3 d-none d-xl-inline-block">Hello, <span class="e-mail">maria@gr.co</span></p>
 			        	<a class="pt-2 pb-3 d-none d-xl-inline-block" href="#">Logout</a>
 			        	<div id="sidebarCollapse" class="wrapper py-1 d-inline-block d-xl-none">
 							<div class="menu-trigger first">
@@ -62,7 +62,7 @@
 				</div>
             </div>
             <ul class="mb-5">
-            	<li><a href="#">Hello, <span class="e-mail">maria@gr.co</span></a></li>
+            	<li><p>Hello, <span class="e-mail">maria@gr.co</span></p></li>
             	<li><a href="index.html">Home</a></li>
             	<li><a href="stats.html">Stats</a></li>
             	<li><a class="active" href="connect-to-wallet.html">Connect to Wallet</a></li>

--- a/src/email-verification-successfully.html
+++ b/src/email-verification-successfully.html
@@ -38,7 +38,7 @@
 				        <a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="settings.html">Settings</a>
 			        </div>
 			        <div class="col-3 px-0 position-relative d-flex justify-content-end">
-			        	<a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="#">Hello, <span class="e-mail">maria@gr.co</span></a>
+			        	<p class="mr-5 pt-2 pb-3 d-none d-xl-inline-block">Hello, <span class="e-mail">maria@gr.co</span></p>
 			        	<a class="pt-2 pb-3 d-none d-xl-inline-block" href="#">Logout</a>
 			        	<div id="sidebarCollapse" class="wrapper py-1 d-inline-block d-xl-none">
 							<div class="menu-trigger first">
@@ -62,7 +62,7 @@
 				</div>
             </div>
             <ul class="mb-5">
-            	<li><a href="#">Hello, <span class="e-mail">maria@gr.co</span></a></li>
+            	<li><p>Hello, <span class="e-mail">maria@gr.co</span></p></li>
             	<li><a href="index.html">Home</a></li>
             	<li><a href="stats.html">Stats</a></li>
             	<li><a class="active" href="connect-to-wallet.html">Connect to Wallet</a></li>

--- a/src/index.html
+++ b/src/index.html
@@ -38,7 +38,7 @@
               <a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="settings.html">Settings</a>
             </div>
             <div class="col-3 px-0 position-relative d-flex justify-content-end">
-              <a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="#">Hello, <span class="e-mail">maria@gr.co</span></a>
+              <p class="mr-5 pt-2 pb-3 d-none d-xl-inline-block">Hello, <span class="e-mail">maria@gr.co</span></p>
               <a class="pt-2 pb-3 d-none d-xl-inline-block" href="#">Logout</a>
               <div id="sidebarCollapse" class="wrapper py-1 d-inline-block d-xl-none">
             <div class="menu-trigger first">
@@ -62,7 +62,7 @@
         </div>
       </div>
       <ul class="mb-5">
-        <li><a href="#">Hello, <span class="e-mail">maria@gr.co</span></a></li>
+        <li><p>Hello, <span class="e-mail">maria@gr.co</span></p></li>
         <li><a href="index.html">Home</a></li>
         <li><a href="stats.html">Stats</a></li>
         <li><a class="active" href="connect-to-wallet.html">Connect to Wallet</a></li>

--- a/src/login.html
+++ b/src/login.html
@@ -38,7 +38,7 @@
 				        <a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="settings.html">Settings</a>
 			        </div>
 			        <div class="col-3 px-0 position-relative d-flex justify-content-end">
-			        	<a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="#">Hello, <span class="e-mail">maria@gr.co</span></a>
+			        	<p class="mr-5 pt-2 pb-3 d-none d-xl-inline-block">Hello, <span class="e-mail">maria@gr.co</span></p>
 			        	<a class="pt-2 pb-3 d-none d-xl-inline-block" href="#">Logout</a>
 			        	<div id="sidebarCollapse" class="wrapper py-1 d-inline-block d-xl-none">
 							<div class="menu-trigger first">
@@ -62,7 +62,7 @@
 				</div>
             </div>
             <ul class="mb-5">
-            	<li><a href="#">Hello, <span class="e-mail">maria@gr.co</span></a></li>
+            	<li><p>Hello, <span class="e-mail">maria@gr.co</span></p></li>
             	<li><a href="index.html">Home</a></li>
             	<li><a href="stats.html">Stats</a></li>
             	<li><a class="active" href="connect-to-wallet.html">Connect to Wallet</a></li>

--- a/src/low-fee-tickets.html
+++ b/src/low-fee-tickets.html
@@ -38,7 +38,7 @@
 				        <a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="settings.html">Settings</a>
 			        </div>
 			        <div class="col-3 px-0 position-relative d-flex justify-content-end">
-			        	<a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="#">Hello, <span class="e-mail">maria@gr.co</span></a>
+			        	<p class="mr-5 pt-2 pb-3 d-none d-xl-inline-block">Hello, <span class="e-mail">maria@gr.co</span></p>
 			        	<a class="pt-2 pb-3 d-none d-xl-inline-block" href="#">Logout</a>
 			        	<div id="sidebarCollapse" class="wrapper py-1 d-inline-block d-xl-none">
 							<div class="menu-trigger first">
@@ -62,7 +62,7 @@
 				</div>
             </div>
             <ul class="mb-5">
-            	<li><a href="#">Hello, <span class="e-mail">maria@gr.co</span></a></li>
+            	<li><p>Hello, <span class="e-mail">maria@gr.co</span></p></li>
             	<li><a href="index.html">Home</a></li>
             	<li><a href="stats.html">Stats</a></li>
             	<li><a class="active" href="connect-to-wallet.html">Connect to Wallet</a></li>

--- a/src/password-update.html
+++ b/src/password-update.html
@@ -38,7 +38,7 @@
 				        <a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="settings.html">Settings</a>
 			        </div>
 			        <div class="col-3 px-0 position-relative d-flex justify-content-end">
-			        	<a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="#">Hello, <span class="e-mail">maria@gr.co</span></a>
+			        	<p class="mr-5 pt-2 pb-3 d-none d-xl-inline-block">Hello, <span class="e-mail">maria@gr.co</span></p>
 			        	<a class="pt-2 pb-3 d-none d-xl-inline-block" href="#">Logout</a>
 			        	<div id="sidebarCollapse" class="wrapper py-1 d-inline-block d-xl-none">
 							<div class="menu-trigger first">
@@ -62,7 +62,7 @@
 				</div>
             </div>
             <ul class="mb-5">
-            	<li><a href="#">Hello, <span class="e-mail">maria@gr.co</span></a></li>
+            	<li><p>Hello, <span class="e-mail">maria@gr.co</span></p></li>
             	<li><a href="index.html">Home</a></li>
             	<li><a href="stats.html">Stats</a></li>
             	<li><a class="active" href="connect-to-wallet.html">Connect to Wallet</a></li>

--- a/src/password-updated.html
+++ b/src/password-updated.html
@@ -38,7 +38,7 @@
 				        <a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="settings.html">Settings</a>
 			        </div>
 			        <div class="col-3 px-0 position-relative d-flex justify-content-end">
-			        	<a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="#">Hello, <span class="e-mail">maria@gr.co</span></a>
+			        	<p class="mr-5 pt-2 pb-3 d-none d-xl-inline-block">Hello, <span class="e-mail">maria@gr.co</span></p>
 			        	<a class="pt-2 pb-3 d-none d-xl-inline-block" href="#">Logout</a>
 			        	<div id="sidebarCollapse" class="wrapper py-1 d-inline-block d-xl-none">
 							<div class="menu-trigger first">
@@ -62,7 +62,7 @@
 				</div>
             </div>
             <ul class="mb-5">
-            	<li><a href="#">Hello, <span class="e-mail">maria@gr.co</span></a></li>
+            	<li><p>Hello, <span class="e-mail">maria@gr.co</span></p></li>
             	<li><a href="index.html">Home</a></li>
             	<li><a href="stats.html">Stats</a></li>
             	<li><a class="active" href="connect-to-wallet.html">Connect to Wallet</a></li>

--- a/src/register.html
+++ b/src/register.html
@@ -38,7 +38,7 @@
 				        <a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="settings.html">Settings</a>
 			        </div>
 			        <div class="col-3 px-0 position-relative d-flex justify-content-end">
-			        	<a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="#">Hello, <span class="e-mail">maria@gr.co</span></a>
+			        	<p class="mr-5 pt-2 pb-3 d-none d-xl-inline-block">Hello, <span class="e-mail">maria@gr.co</span></p>
 			        	<a class="pt-2 pb-3 d-none d-xl-inline-block" href="#">Logout</a>
 			        	<div id="sidebarCollapse" class="wrapper py-1 d-inline-block d-xl-none">
 							<div class="menu-trigger first">
@@ -62,7 +62,7 @@
 				</div>
             </div>
             <ul class="mb-5">
-            	<li><a href="#">Hello, <span class="e-mail">maria@gr.co</span></a></li>
+            	<li><p>Hello, <span class="e-mail">maria@gr.co</span></p></li>
             	<li><a href="index.html">Home</a></li>
             	<li><a href="stats.html">Stats</a></li>
             	<li><a class="active" href="connect-to-wallet.html">Connect to Wallet</a></li>

--- a/src/reset-password-link.html
+++ b/src/reset-password-link.html
@@ -38,7 +38,7 @@
 				        <a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="settings.html">Settings</a>
 			        </div>
 			        <div class="col-3 px-0 position-relative d-flex justify-content-end">
-			        	<a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="#">Hello, <span class="e-mail">maria@gr.co</span></a>
+			        	<p class="mr-5 pt-2 pb-3 d-none d-xl-inline-block">Hello, <span class="e-mail">maria@gr.co</span></p>
 			        	<a class="pt-2 pb-3 d-none d-xl-inline-block" href="#">Logout</a>
 			        	<div id="sidebarCollapse" class="wrapper py-1 d-inline-block d-xl-none">
 							<div class="menu-trigger first">
@@ -62,7 +62,7 @@
 				</div>
             </div>
             <ul class="mb-5">
-            	<li><a href="#">Hello, <span class="e-mail">maria@gr.co</span></a></li>
+            	<li><p>Hello, <span class="e-mail">maria@gr.co</span></p></li>
             	<li><a href="index.html">Home</a></li>
             	<li><a href="stats.html">Stats</a></li>
             	<li><a class="active" href="connect-to-wallet.html">Connect to Wallet</a></li>

--- a/src/reset-password.html
+++ b/src/reset-password.html
@@ -38,7 +38,7 @@
 				        <a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="settings.html">Settings</a>
 			        </div>
 			        <div class="col-3 px-0 position-relative d-flex justify-content-end">
-			        	<a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="#">Hello, <span class="e-mail">maria@gr.co</span></a>
+			        	<p class="mr-5 pt-2 pb-3 d-none d-xl-inline-block">Hello, <span class="e-mail">maria@gr.co</span></p>
 			        	<a class="pt-2 pb-3 d-none d-xl-inline-block" href="#">Logout</a>
 			        	<div id="sidebarCollapse" class="wrapper py-1 d-inline-block d-xl-none">
 							<div class="menu-trigger first">
@@ -62,7 +62,7 @@
 				</div>
             </div>
             <ul class="mb-5">
-            	<li><a href="#">Hello, <span class="e-mail">maria@gr.co</span></a></li>
+            	<li><p>Hello, <span class="e-mail">maria@gr.co</span></p></li>
             	<li><a href="index.html">Home</a></li>
             	<li><a href="stats.html">Stats</a></li>
             	<li><a class="active" href="connect-to-wallet.html">Connect to Wallet</a></li>

--- a/src/settings.html
+++ b/src/settings.html
@@ -38,7 +38,7 @@
 				        <a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="settings.html">Settings</a>
 			        </div>
 			        <div class="col-3 px-0 position-relative d-flex justify-content-end">
-			        	<a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="#">Hello, <span class="e-mail">maria@gr.co</span></a>
+			        	<p class="mr-5 pt-2 pb-3 d-none d-xl-inline-block">Hello, <span class="e-mail">maria@gr.co</span></p>
 			        	<a class="pt-2 pb-3 d-none d-xl-inline-block" href="#">Logout</a>
 			        	<div id="sidebarCollapse" class="wrapper py-1 d-inline-block d-xl-none">
 							<div class="menu-trigger first">
@@ -62,7 +62,7 @@
 				</div>
             </div>
             <ul class="mb-5">
-            	<li><a href="#">Hello, <span class="e-mail">maria@gr.co</span></a></li>
+            	<li><p>Hello, <span class="e-mail">maria@gr.co</span></p></li>
             	<li><a href="index.html">Home</a></li>
             	<li><a href="stats.html">Stats</a></li>
             	<li><a class="active" href="connect-to-wallet.html">Connect to Wallet</a></li>

--- a/src/stats.html
+++ b/src/stats.html
@@ -38,7 +38,7 @@
 				        <a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="settings.html">Settings</a>
 			        </div>
 			        <div class="col-3 px-0 position-relative d-flex justify-content-end">
-			        	<a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="#">Hello, <span class="e-mail">maria@gr.co</span></a>
+			        	<p class="mr-5 pt-2 pb-3 d-none d-xl-inline-block">Hello, <span class="e-mail">maria@gr.co</span></p>
 			        	<a class="pt-2 pb-3 d-none d-xl-inline-block" href="#">Logout</a>
 			        	<div id="sidebarCollapse" class="wrapper py-1 d-inline-block d-xl-none">
 							<div class="menu-trigger first">
@@ -62,7 +62,7 @@
 				</div>
             </div>
             <ul class="mb-5">
-            	<li><a href="#">Hello, <span class="e-mail">maria@gr.co</span></a></li>
+            	<li><p>Hello, <span class="e-mail">maria@gr.co</span></p></li>
             	<li><a href="index.html">Home</a></li>
             	<li><a href="stats.html">Stats</a></li>
             	<li><a class="active" href="connect-to-wallet.html">Connect to Wallet</a></li>

--- a/src/status.html
+++ b/src/status.html
@@ -38,7 +38,7 @@
 				        <a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="settings.html">Settings</a>
 			        </div>
 			        <div class="col-3 px-0 position-relative d-flex justify-content-end">
-			        	<a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="#">Hello, <span class="e-mail">maria@gr.co</span></a>
+			        	<p class="mr-5 pt-2 pb-3 d-none d-xl-inline-block">Hello, <span class="e-mail">maria@gr.co</span></p>
 			        	<a class="pt-2 pb-3 d-none d-xl-inline-block" href="#">Logout</a>
 			        	<div id="sidebarCollapse" class="wrapper py-1 d-inline-block d-xl-none">
 							<div class="menu-trigger first">
@@ -62,7 +62,7 @@
 				</div>
             </div>
             <ul class="mb-5">
-            	<li><a href="#">Hello, <span class="e-mail">maria@gr.co</span></a></li>
+            	<li><p>Hello, <span class="e-mail">maria@gr.co</span></p></li>
             	<li><a href="index.html">Home</a></li>
             	<li><a href="stats.html">Stats</a></li>
             	<li><a class="active" href="connect-to-wallet.html">Connect to Wallet</a></li>

--- a/src/styles/partials/_header.scss
+++ b/src/styles/partials/_header.scss
@@ -2,19 +2,22 @@
 	height: 60px;
 	background-color: #f9fafa;
 
-	a {
+	a, p {
 		font-size: 15px;
 		line-height: 1.13;
 		letter-spacing: normal;
 		color: #8997a5;
 
+	}
+
+	a {
 		&:hover, &:focus, &.active {
 			text-decoration: none;
 			color: #091440;
 			border-bottom: 5px solid #2ed8a3;
 		}
 	}
-
+	
 	.logo {
 
 		&--logo {
@@ -144,18 +147,21 @@
 
 		li {
 
-			a {
+			a, p {
 				padding: 22px 60px 22px;
 				font-size: 15px;
 				line-height: 1.13;
 				color: #8997a5;
-				display: block;
+					display: block;
 				transition: 0.25s;
+				margin: 0;
 
 				@include media-breakpoint-down(sm) {
 					padding: 22px 30px 22px;
 				}
+			}
 
+			a {
 				&.active, &:hover, &:focus {
 					padding-left: 25px;
 					background-color: #fff;

--- a/src/tickets.html
+++ b/src/tickets.html
@@ -38,7 +38,7 @@
 				        <a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="settings.html">Settings</a>
 			        </div>
 			        <div class="col-3 px-0 position-relative d-flex justify-content-end">
-			        	<a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="#">Hello, <span class="e-mail">maria@gr.co</span></a>
+			        	<p class="mr-5 pt-2 pb-3 d-none d-xl-inline-block">Hello, <span class="e-mail">maria@gr.co</span></p>
 			        	<a class="pt-2 pb-3 d-none d-xl-inline-block" href="#">Logout</a>
 			        	<div id="sidebarCollapse" class="wrapper py-1 d-inline-block d-xl-none">
 							<div class="menu-trigger first">
@@ -62,7 +62,7 @@
 				</div>
             </div>
             <ul class="mb-5">
-            	<li><a href="#">Hello, <span class="e-mail">maria@gr.co</span></a></li>
+            	<li><p>Hello, <span class="e-mail">maria@gr.co</span></p></li>
             	<li><a href="index.html">Home</a></li>
             	<li><a href="stats.html">Stats</a></li>
             	<li><a class="active" href="connect-to-wallet.html">Connect to Wallet</a></li>

--- a/src/voting.html
+++ b/src/voting.html
@@ -38,7 +38,7 @@
 				        <a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="settings.html">Settings</a>
 			        </div>
 			        <div class="col-3 px-0 position-relative d-flex justify-content-end">
-			        	<a class="mr-5 pt-2 pb-3 d-none d-xl-inline-block" href="#">Hello, <span class="e-mail">maria@gr.co</span></a>
+			        	<p class="mr-5 pt-2 pb-3 d-none d-xl-inline-block">Hello, <span class="e-mail">maria@gr.co</span></p>
 			        	<a class="pt-2 pb-3 d-none d-xl-inline-block" href="#">Logout</a>
 			        	<div id="sidebarCollapse" class="wrapper py-1 d-inline-block d-xl-none">
 							<div class="menu-trigger first">
@@ -62,7 +62,7 @@
 				</div>
             </div>
             <ul class="mb-5">
-            	<li><a href="#">Hello, <span class="e-mail">maria@gr.co</span></a></li>
+            	<li><p>Hello, <span class="e-mail">maria@gr.co</span></p></li>
             	<li><a href="index.html">Home</a></li>
             	<li><a href="stats.html">Stats</a></li>
             	<li><a class="active" href="connect-to-wallet.html">Connect to Wallet</a></li>


### PR DESCRIPTION
This PR removes the link from `Hello, email@email.com' greeting message in both the top toolbar and collapsed sidebar. 